### PR TITLE
Create Halyard base image

### DIFF
--- a/create_base_image/create_base_image.sh
+++ b/create_base_image/create_base_image.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Creates a base image suitable for booting cuttlefish on GCE
+
+source "create_base_image_hostlib.sh"
+
+FLAGS "$@" || exit 1
+main "${FLAGS_ARGV[@]}"

--- a/create_base_image/create_base_image_gce.sh
+++ b/create_base_image/create_base_image_gce.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+set -x
+set -o errexit
+
+sudo apt-get update
+
+# Stuff we need to get build support
+
+sudo apt install -y debhelper ubuntu-dev-tools equivs cloud-utils \
+  "${extra_packages[@]}"
+
+# Install the cuttlefish build deps
+
+for dsc in *.dsc; do
+  yes | sudo mk-build-deps -i "${dsc}" -t apt-get
+done
+
+# Installing the build dependencies left some .deb files around. Remove them
+# to keep them from landing on the image.
+yes | rm -f *.deb
+
+for dsc in *.dsc; do
+  # Unpack the source and build it
+
+  dpkg-source -x "${dsc}"
+  dir="$(basename "${dsc}" .dsc)"
+  dir="${dir/_/-}"
+  pushd "${dir}/"
+  debuild -uc -us
+  popd
+done
+
+# Now gather all of the *.deb files to copy them into the image
+debs=(*.deb)
+
+tmp_debs=()
+for i in "${debs[@]}"; do
+  tmp_debs+=(/tmp/"$(basename "$i")")
+done
+
+# Fix partition table size
+sudo growpart /dev/sdb 1
+sudo e2fsck -f /dev/sdb1
+sudo resize2fs /dev/sdb1
+
+# Now install the packages on the disk
+sudo mkdir /mnt/image
+sudo mount /dev/sdb1 /mnt/image
+cp "${debs[@]}" /mnt/image/tmp
+sudo cp -r cuttlefish /mnt/image/usr/local/share
+sudo chmod -R 755 /mnt/image/usr/local/share/cuttlefish 
+sudo mount -t sysfs none /mnt/image/sys
+sudo mount -t proc none /mnt/image/proc
+sudo mount --bind /dev/ /mnt/image/dev
+sudo mount --bind /dev/pts /mnt/image/dev/pts
+sudo mount --bind /run /mnt/image/run
+# resolv.conf is needed on Debian but not Ubuntu
+sudo cp /etc/resolv.conf /mnt/image/etc/
+sudo chroot /mnt/image /usr/bin/apt update
+sudo chroot /mnt/image /usr/bin/apt install -y "${tmp_debs[@]}"
+# install tools dependencies
+sudo chroot /mnt/image /usr/bin/apt install -y python
+sudo chroot /mnt/image /usr/bin/apt install -y openjdk-11-jre
+sudo chroot /mnt/image /usr/bin/apt install -y unzip bzip2 lzop
+sudo chroot /mnt/image /usr/bin/apt install -y aapt
+sudo chroot /mnt/image /usr/bin/apt install -y screen # needed by tradefed
+
+sudo chroot /mnt/image /usr/bin/find /home -ls
+
+
+# Install GPU driver dependencies
+sudo chroot /mnt/image /usr/bin/apt install -y gcc
+sudo chroot /mnt/image /usr/bin/apt install -y linux-source
+sudo chroot /mnt/image /usr/bin/apt install -y linux-headers-`uname -r`
+sudo chroot /mnt/image /usr/bin/apt install -y make
+
+# Download the latest GPU driver installer
+gsutil cp \
+  $(gsutil ls gs://nvidia-drivers-us-public/GRID/GRID*/*-Linux-x86_64-*.run \
+    | sort \
+    | tail -n 1) \
+  /mnt/image/tmp/nvidia-driver-installer.run
+
+# Make GPU driver installer executable
+chmod +x /mnt/image/tmp/nvidia-driver-installer.run
+
+# Install the latest GPU driver with default options and the dispatch libs
+sudo chroot /mnt/image /tmp/nvidia-driver-installer.run \
+  --silent \
+  --install-libglvnd
+
+# Cleanup after install
+rm /mnt/image/tmp/nvidia-driver-installer.run
+
+# Verify
+query_nvidia() {
+  sudo chroot /mnt/image nvidia-smi --format=csv,noheader --query-gpu="$@"
+}
+
+if [[ $(query_nvidia "count") != "1" ]]; then
+  echo "Failed to detect GPU."
+  exit 1
+fi
+
+if [[ $(query_nvidia "driver_version") == "" ]]; then
+  echo "Failed to detect GPU driver."
+  exit 1
+fi
+
+# Vulkan loader
+sudo chroot /mnt/image /usr/bin/apt install -y libvulkan1
+
+# Clean up the builder's version of resolv.conf
+sudo rm /mnt/image/etc/resolv.conf
+
+# Skip unmounting:
+#  Sometimes systemd starts, making it hard to unmount
+#  In any case we'll unmount cleanly when the instance shuts down
+
+echo IMAGE_WAS_CREATED

--- a/create_base_image/create_base_image_gce.sh
+++ b/create_base_image/create_base_image_gce.sh
@@ -7,8 +7,7 @@ sudo apt-get update
 
 # Stuff we need to get build support
 
-sudo apt install -y debhelper ubuntu-dev-tools equivs cloud-utils \
-  "${extra_packages[@]}"
+sudo apt install -y debhelper ubuntu-dev-tools equivs cloud-utils
 
 # Install the cuttlefish build deps
 

--- a/create_base_image/create_base_image_hostlib.sh
+++ b/create_base_image/create_base_image_hostlib.sh
@@ -208,7 +208,7 @@ main() {
     "${PZ[@]}" "${FLAGS_build_instance}"
 
   gcloud compute images create \
-    --project="${FLAGS_dest_project}" \
+    --project="${FLAGS_build_project}" \
     --source-disk="${FLAGS_dest_image}" \
     --source-disk-zone="${FLAGS_build_zone}" \
     --licenses=https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx \
@@ -216,6 +216,13 @@ main() {
     "${FLAGS_dest_image}"
 
   gcloud compute disks delete -q "${PZ[@]}" \
+    "${FLAGS_dest_image}"
+
+  gcloud compute images create \
+    --project="${FLAGS_dest_project}" \
+    --source-image="${FLAGS_dest_image}" \
+    --source-image-project="${FLAGS_build_project}" \
+    "${dest_family_flag[@]}" \
     "${FLAGS_dest_image}"
 
 }

--- a/create_base_image/create_base_image_hostlib.sh
+++ b/create_base_image/create_base_image_hostlib.sh
@@ -2,7 +2,7 @@
 
 # Common code to build a host image on GCE
 
-source "shflags/shflags"
+source "../external/shflags/shflags"
 
 # Build instance info
 DEFINE_string build_instance \

--- a/create_base_image/create_base_image_hostlib.sh
+++ b/create_base_image/create_base_image_hostlib.sh
@@ -72,12 +72,12 @@ fetch_cf_package() {
   dpkg-source -b "${debian_dir}"
   rm -rf "${debian_dir}"
 
-  # Gets cf-common version
-  for dsc in *dsc; do
-    CF_VER=$(basename "${dsc/*_/}" .dsc)
-    CF_VER="${CF_VER//\./-}"
-  done
+}
 
+get_cf_version() {
+  CF_VER=(*.dsc)
+  CF_VER=$(basename "${CF_VER/*_/}" .dsc)
+  CF_VER="${CF_VER//\./-}"
 }
 
 # Gets build artifacts from Android Build API
@@ -119,6 +119,7 @@ main() {
   scratch_dir="$(mktemp -d)"
   pushd "${scratch_dir}"
     fetch_cf_package "${FLAGS_repository_url}" "${FLAGS_repository_branch}"
+    get_cf_version
     mkdir cuttlefish
     pushd cuttlefish
       fetch_build_artifacts "${FLAGS_build_target}" "${FLAGS_build_id}"

--- a/create_base_image/create_base_image_hostlib.sh
+++ b/create_base_image/create_base_image_hostlib.sh
@@ -26,7 +26,7 @@ DEFINE_string dest_image "" \
   "Image to create" "o"
 DEFINE_string dest_family "" \
   "Image family to add the image to" "f"
-DEFINE_string dest_project "$(gcloud config get-value project)" \
+DEFINE_string dest_project "" \
   "Project to use for the new image" "p"
 DEFINE_boolean respin false \
   "Whether to replace an image if its name is taken"
@@ -218,11 +218,13 @@ main() {
   gcloud compute disks delete -q "${PZ[@]}" \
     "${FLAGS_dest_image}"
 
-  gcloud compute images create \
-    --project="${FLAGS_dest_project}" \
-    --source-image="${FLAGS_dest_image}" \
-    --source-image-project="${FLAGS_build_project}" \
-    "${dest_family_flag[@]}" \
-    "${FLAGS_dest_image}"
+  if [[ -n "${FLAGS_dest_project}" && "${FLAGS_dest_project}" != "${FLAGS_build_project}" ]]; then
+    gcloud compute images create \
+      --project="${FLAGS_dest_project}" \
+      --source-image="${FLAGS_dest_image}" \
+      --source-image-project="${FLAGS_build_project}" \
+      "${dest_family_flag[@]}" \
+      "${FLAGS_dest_image}"
+  fi
 
 }

--- a/create_base_image/create_base_image_hostlib.sh
+++ b/create_base_image/create_base_image_hostlib.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+# Common code to build a host image on GCE
+
+source "shflags/shflags"
+
+# Build instance info
+DEFINE_string build_instance \
+  "${USER}-build" "Instance name to create for the build" "i"
+DEFINE_string build_project "$(gcloud config get-value project)" \
+  "Project to use for scratch"
+DEFINE_string build_zone "$(gcloud config get-value compute/zone)" \
+  "Zone to use for scratch resources"
+DEFINE_string build_tags "" "Tags to add to the GCE instance"
+
+# Build artifacts info
+DEFINE_string build_branch "aosp-master" \
+  "Branch to extract build artifacts" "b"
+DEFINE_string build_target "aosp_cf_x86_phone-userdebug" \
+  "Target device to extract build artifacts"
+DEFINE_string build_id "" \
+  "Build id used to extract build artifacts"
+
+# New image info
+DEFINE_string dest_image "" \
+  "Image to create" "o"
+DEFINE_string dest_family "" \
+  "Image family to add the image to" "f"
+DEFINE_string dest_project "$(gcloud config get-value project)" \
+  "Project to use for the new image" "p"
+
+# Base image info
+DEFINE_string source_image_family "debian-10" \
+  "Image family to use as the base" "s"
+DEFINE_string source_image_project "debian-cloud" \
+  "Project holding the base image" "m"
+
+# CF repo info
+DEFINE_string repository_url \
+  "https://github.com/google/android-cuttlefish.git" \
+  "URL to the repository with host changes" "u"
+DEFINE_string repository_branch master \
+  "Branch to check out"
+
+
+
+fatal_echo() {
+  echo "$1"
+  exit 1
+}
+
+# Sleeps while trying to connect to instance
+wait_for_instance() {
+  alive=""
+  while [[ -z "${alive}" ]]; do
+    sleep 5
+    alive="$(gcloud compute ssh "$@" -- uptime || true)"
+  done
+}
+
+# Gets debian packages from Cuttlefish repo
+fetch_cf_package() {
+
+  local url="$1"
+  local branch="$2"
+  local repository_dir="${url/*\//}"
+  local debian_dir="$(basename "${repository_dir}" .git)"
+
+  git clone "${url}" -b "${branch}"
+  dpkg-source -b "${debian_dir}"
+  rm -rf "${debian_dir}"
+
+  # Gets cf-common version
+  for dsc in *dsc; do
+    CF_VER=$(basename "${dsc/*_/}" .dsc)
+    CF_VER="${CF_VER//\./-}"
+  done
+
+}
+
+# Gets build artifacts from Android Build API
+fetch_build_artifacts() {
+
+  local target="$1"
+  local build_id="$2"
+  
+  FETCH_ARTIFACTS=`mktemp`
+  curl "https://www.googleapis.com/android/internal/build/v3/builds/$build_id/$target/attempts/latest/artifacts/fetch_cvd?alt=media" -o $FETCH_ARTIFACTS
+
+  chmod +x $FETCH_ARTIFACTS
+  eval $FETCH_ARTIFACTS
+
+}
+
+
+main() {
+  set -o errexit
+  set -x
+
+  # SETUP AND SOURCE FILES EXTRACTION
+
+  # Flags setup
+  PZ=(--project=${FLAGS_build_project} --zone=${FLAGS_build_zone})
+  if [[ -n "${FLAGS_build_tags}" ]]; then
+    build_tags=("--tags=${FLAGS_build_tags}")
+  else
+    build_tags=()
+  fi
+
+  # Gets latest successful build_id from target branch in case no build_id is specified
+  if [[ -z "${FLAGS_build_id}" ]]; then
+    FLAGS_build_id=`curl "https://www.googleapis.com/android/internal/build/v3/builds?branch=$FLAGS_build_branch&buildAttemptStatus=complete&buildType=submitted&maxResults=1&successful=true&target=$FLAGS_build_target" 2>/dev/null | \
+    python2 -c "import sys, json; print json.load(sys.stdin)['builds'][0]['buildId']"`
+  fi
+
+  # Fetches cuttlefish common packages and target build artifacts
+  scratch_dir="$(mktemp -d)"
+  pushd "${scratch_dir}"
+    fetch_cf_package "${FLAGS_repository_url}" "${FLAGS_repository_branch}"
+    mkdir cuttlefish
+    pushd cuttlefish
+      fetch_build_artifacts "${FLAGS_build_target}" "${FLAGS_build_id}"
+    popd
+  popd
+  source_files=(
+    "create_base_image_gce.sh"
+    ${scratch_dir}/*
+  )
+
+  # Sets image and family names in case none were specified
+  FLAGS_build_target="${FLAGS_build_target//_/-}"
+  if [[ -z "${FLAGS_dest_image}" ]]; then
+    FLAGS_dest_image="halyard-${CF_VER}-${FLAGS_build_branch}-${FLAGS_build_target}-${FLAGS_build_id}"
+  fi
+  if [[ -z "${FLAGS_dest_family}" ]]; then
+    FLAGS_dest_family="halyard-${FLAGS_build_branch}-${FLAGS_build_target}"
+  fi
+
+  if [[ -n "${FLAGS_dest_family}" ]]; then
+    dest_family_flag=("--family=${FLAGS_dest_family}")
+  else
+    dest_family_flag=()
+  fi
+
+  # Deletes instances, disks and images with names that will be used for build
+  delete_instances=("${FLAGS_build_instance}" "${FLAGS_dest_image}")
+  gcloud compute instances delete -q \
+    "${PZ[@]}" "${delete_instances[@]}" || echo Not running
+  gcloud compute disks delete -q \
+    "${PZ[@]}" "${FLAGS_dest_image}" || echo No scratch disk
+  gcloud compute images delete -q \
+    --project="${FLAGS_build_project}" "${FLAGS_dest_image}"  || echo Not respinning
+
+
+  # BUILD INSTANCE AND DISK CREATION
+
+  gcloud compute disks create \
+    "${PZ[@]}" \
+    --image-family="${FLAGS_source_image_family}" \
+    --image-project="${FLAGS_source_image_project}" \
+    --size=30GB \
+    "${FLAGS_dest_image}"
+
+
+  # Checks if gpu available 
+  local gpu_type="nvidia-tesla-p100-vws"
+  gcloud compute accelerator-types describe "${gpu_type}" "${PZ[@]}" || \
+    fatal_echo "Please use a zone with ${gpu_type} GPUs available."
+
+  gcloud compute instances create \
+    "${PZ[@]}" \
+    --machine-type=n1-standard-16 \
+    --image-family="${FLAGS_source_image_family}" \
+    --image-project="${FLAGS_source_image_project}" \
+    --boot-disk-size=200GiB \
+    --accelerator="type=${gpu_type},count=1" \
+    --maintenance-policy=TERMINATE \
+    "${build_tags[@]}" \
+    "${FLAGS_build_instance}"
+
+  # Wait until instance is booted
+  wait_for_instance "${PZ[@]}" "${FLAGS_build_instance}"
+
+  gcloud compute instances attach-disk \
+      "${PZ[@]}" "${FLAGS_build_instance}" --disk="${FLAGS_dest_image}"
+
+  gcloud compute scp "${PZ[@]}" -- -r \
+    "${source_files[@]}" \
+    "${FLAGS_build_instance}:"
+
+
+  # IMAGE CREATION
+
+  gcloud compute ssh "${PZ[@]}" "${FLAGS_build_instance}" -- \
+    ./create_base_image_gce.sh
+
+  gcloud compute instances delete -q \
+    "${PZ[@]}" "${FLAGS_build_instance}"
+
+  gcloud compute images create \
+    --project="${FLAGS_build_project}" \
+    --source-disk="${FLAGS_dest_image}" \
+    --source-disk-zone="${FLAGS_build_zone}" \
+    --licenses=https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx \
+    "${dest_family_flag[@]}" \
+    "${FLAGS_dest_image}"
+
+  gcloud compute disks delete -q "${PZ[@]}" \
+    "${FLAGS_dest_image}"
+  
+  cat <<EOF
+    echo Test and if this looks good, consider releasing it via:
+
+    gcloud compute images create \
+      --project="${FLAGS_dest_project}" \
+      --source-image="${FLAGS_dest_image}" \
+      --source-image-project="${FLAGS_build_project}" \
+      "${dest_family_flag[@]}" \
+      "${FLAGS_dest_image}"
+EOF
+
+}


### PR DESCRIPTION
Fixes #1 
Downloads Cuttlefish host packages and android build artifacts and creates a gcloud base image.

## Features Added

- Build artifacts flags to set a specific branch, target, or build id
- Fetches build artifacts using external android build API
- Copies android img files into /usr/local/share

## Pending Fixes/Improvements
- b/16342398 - when setting the `--system_image_dir` flag different from the HOME dir.
- Build artifacts could be downloaded directly into base image disk instead of copying it from build instance