### PR TITLE
Download CF common and build artifacts from GCE instance script

### DIFF
--- a/create_base_image/create_base_image_gce.sh
+++ b/create_base_image/create_base_image_gce.sh
@@ -6,7 +6,13 @@ set -o errexit
 sudo apt-get update
 
 # Stuff we need to get build support
-sudo apt install -y debhelper ubuntu-dev-tools equivs cloud-utils git
+sudo apt install -y debhelper ubuntu-dev-tools equivs cloud-utils git bsdtar
+
+repository_url=$1
+repository_branch=$2
+build_branch=$3
+build_target=$4
+build_id=$5
 
 # Gets debian packages from Cuttlefish repo
 fetch_cf_package() {
@@ -26,10 +32,28 @@ get_cf_version() {
   cf_version="${cf_version//\./-}"
 }
 
-fetch_cf_package "$1" "$2"
+# Gets build artifacts from Android Build API
+fetch_build_artifacts() {
+  local target="$1"
+  local build_id="$2"
+  
+  FETCH_ARTIFACTS="$(mktemp)"
+  curl "https://www.googleapis.com/android/internal/build/v3/builds/$build_id/$target/attempts/latest/artifacts/fetch_cvd?alt=media" -o $FETCH_ARTIFACTS
+  chmod +x $FETCH_ARTIFACTS
+  eval $FETCH_ARTIFACTS
+}
+
+fetch_cf_package "${repository_url}" "${repository_branch}" 
 get_cf_version
 
-name_values=("cf_version=${cf_version}")
+# Gets latest successful build_id from target branch in case no build_id is specified
+if [[ -z "${build_id}" ]]; then
+  build_id=`curl "https://www.googleapis.com/android/internal/build/v3/builds?branch=$build_branch&buildAttemptStatus=complete&buildType=submitted&maxResults=1&successful=true&target=$build_target" 2>/dev/null | \
+  python2 -c "import sys, json; print json.load(sys.stdin)['builds'][0]['buildId']"`
+fi
+
+# Writes dest image and family values into file
+name_values=("cf_version=${cf_version}" "FLAGS_build_id=${build_id}")
 printf "%s\n" "${name_values[@]}" > image_name_values
 
 # Install the cuttlefish build deps
@@ -69,8 +93,14 @@ sudo resize2fs /dev/sdb1
 sudo mkdir /mnt/image
 sudo mount /dev/sdb1 /mnt/image
 cp "${debs[@]}" /mnt/image/tmp
-sudo cp -r cuttlefish /mnt/image/usr/local/share
-sudo chmod -R 755 /mnt/image/usr/local/share/cuttlefish 
+
+# Fetches build artifacts 
+sudo mkdir /mnt/image/usr/local/share/cuttlefish
+sudo chmod -R 777 /mnt/image/usr/local/share/cuttlefish
+pushd /mnt/image/usr/local/share/cuttlefish
+fetch_build_artifacts "${build_target}" "${build_id}"
+popd
+
 sudo mount -t sysfs none /mnt/image/sys
 sudo mount -t proc none /mnt/image/proc
 sudo mount --bind /dev/ /mnt/image/dev

--- a/create_base_image/create_base_image_gce.sh
+++ b/create_base_image/create_base_image_gce.sh
@@ -6,11 +6,30 @@ set -o errexit
 sudo apt-get update
 
 # Stuff we need to get build support
+sudo apt install -y debhelper ubuntu-dev-tools equivs cloud-utils git
 
-sudo apt install -y debhelper ubuntu-dev-tools equivs cloud-utils
+# Gets debian packages from Cuttlefish repo
+fetch_cf_package() {
+  local url="$1"
+  local branch="$2"
+  local repository_dir="${url/*\//}"
+  local debian_dir="$(basename "${repository_dir}" .git)"
+
+  git clone "${url}" -b "${branch}"
+  dpkg-source -b "${debian_dir}"
+  rm -rf "${debian_dir}"
+}
+
+get_cf_version() {
+  cf_version=(*.dsc)
+  cf_version=$(basename "${cf_version/*_/}" .dsc)
+  cf_version="${cf_version//\./-}"
+}
+
+fetch_cf_package "$1" "$2"
+get_cf_version
 
 # Install the cuttlefish build deps
-
 for dsc in *.dsc; do
   yes | sudo mk-build-deps -i "${dsc}" -t apt-get
 done

--- a/create_base_image/create_base_image_gce.sh
+++ b/create_base_image/create_base_image_gce.sh
@@ -29,6 +29,9 @@ get_cf_version() {
 fetch_cf_package "$1" "$2"
 get_cf_version
 
+name_values=("cf_version=${cf_version}")
+printf "%s\n" "${name_values[@]}" > image_name_values
+
 # Install the cuttlefish build deps
 for dsc in *.dsc; do
   yes | sudo mk-build-deps -i "${dsc}" -t apt-get

--- a/create_base_image/create_base_image_hostlib.sh
+++ b/create_base_image/create_base_image_hostlib.sh
@@ -12,6 +12,7 @@ DEFINE_string build_project "$(gcloud config get-value project)" \
 DEFINE_string build_zone "$(gcloud config get-value compute/zone)" \
   "Zone to use for scratch resources"
 DEFINE_string build_tags "" "Tags to add to the GCE instance"
+IMAGE_DISK="${USER}-image-disk"
 
 # Build artifacts info
 DEFINE_string build_branch "aosp-master" \
@@ -148,9 +149,9 @@ main() {
   # Deletes instances and disks with names that will be used for build
   delete_instances=("${FLAGS_build_instance}" "${FLAGS_dest_image}")
   gcloud compute instances delete -q \
-    "${PZ[@]}" "${delete_instances[@]}" || echo Not running
+    "${PZ[@]}" "${FLAGS_build_instance}" || echo Not running
   gcloud compute disks delete -q \
-    "${PZ[@]}" "${FLAGS_dest_image}" || echo No scratch disk
+    "${PZ[@]}" "${IMAGE_DISK}" || echo No scratch disk
 
   # Checks for existing image with same name
   gcloud compute images describe \
@@ -169,8 +170,7 @@ main() {
     --image-family="${FLAGS_source_image_family}" \
     --image-project="${FLAGS_source_image_project}" \
     --size=30GB \
-    "${FLAGS_dest_image}"
-
+    "${IMAGE_DISK}"
 
   # Checks if gpu available 
   local gpu_type="nvidia-tesla-p100-vws"
@@ -192,7 +192,7 @@ main() {
   wait_for_instance "${PZ[@]}" "${FLAGS_build_instance}"
 
   gcloud compute instances attach-disk \
-      "${PZ[@]}" "${FLAGS_build_instance}" --disk="${FLAGS_dest_image}"
+      "${PZ[@]}" "${FLAGS_build_instance}" --disk="${IMAGE_DISK}"
 
   gcloud compute scp "${PZ[@]}" -- -r \
     "${source_files[@]}" \
@@ -209,14 +209,14 @@ main() {
 
   gcloud compute images create \
     --project="${FLAGS_build_project}" \
-    --source-disk="${FLAGS_dest_image}" \
+    --source-disk="${IMAGE_DISK}" \
     --source-disk-zone="${FLAGS_build_zone}" \
     --licenses=https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx \
     "${dest_family_flag[@]}" \
     "${FLAGS_dest_image}"
 
-  gcloud compute disks delete -q "${PZ[@]}" \
-    "${FLAGS_dest_image}"
+  gcloud compute disks delete -q \
+    "${PZ[@]}" "${IMAGE_DISK}"
 
   if [[ -n "${FLAGS_dest_project}" && "${FLAGS_dest_project}" != "${FLAGS_build_project}" ]]; then
     gcloud compute images create \


### PR DESCRIPTION
Fixes #4, fixes #5, fixes #6 
Downloads Cuttlefish host packages and Android build artifacts in the GCE script and in the image disk directly instead of on hostlib script that runs on local machine.

## Features Added

- Move `fetch_cf_package` and `fetch_build_artifacts`  to `create_base_image_gce.sh`
- Writes cuttlefish common version and build_id to file that is used by hostlib script to define `dest_image` name