### PR TITLE
Resume instance

### DIFF
--- a/halyard_utils.py
+++ b/halyard_utils.py
@@ -1,0 +1,35 @@
+import os
+import time
+
+def wait_for_instance(instance_name, zone):
+    not_running = 1
+    while not_running != 0:
+        time.sleep(5)
+        # uptime returns a value other than 0 when not successful
+        not_running = os.system(f'gcloud compute ssh {instance_name} --zone={zone} -- uptime')
+
+def fatal_error(msg):
+    print(f'Error: {msg}')
+    exit()
+
+def find_instance(driver, instance_name, zone):
+    try:
+        instance = driver.ex_get_node(instance_name, zone)
+    except:
+        instance = None
+    return instance
+
+def find_disk(driver, disk_name, zone):
+    try:
+        disk = driver.ex_get_volume(disk_name, zone)
+    except:
+        disk = None
+    return disk
+
+def find_gpu(driver, gpu_type, zone):
+    try:
+        gpu = driver.ex_get_accelerator_type(
+            gpu_type, zone=zone)
+    except:
+        gpu = None
+    return gpu

--- a/instance/create_instance.py
+++ b/instance/create_instance.py
@@ -53,7 +53,7 @@ except:
 # Stops execution if instance already exists
 instance = utils.find_instance(driver, instance_name, args.zone)
 if instance:
-    fatal_error(f'Instance {instance_name} already exists.')
+    utils.fatal_error(f'Instance {instance_name} already exists.')
 
 build_node = driver.create_node(
     instance_name,

--- a/instance/resume_instance.py
+++ b/instance/resume_instance.py
@@ -1,0 +1,156 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import argparse
+import halyard_utils as utils
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+# Parse flag arguments
+parser = argparse.ArgumentParser()
+
+def add_flag(flag_name, default):
+    parser.add_argument(f'--{flag_name}', dest=flag_name,
+                        action='store', default=default)
+
+# New instance info
+add_flag('user_id', '00001')
+add_flag('zone', 'us-central1-b')
+parser.add_argument('--tag', action='append', dest='tags', default=[])
+
+# Base image version
+add_flag('branch', 'aosp-master')
+add_flag('target' ,'aosp_cf_x86_phone-userdebug')
+
+# GCE Project info
+add_flag('datacenter', 'us-central1-b')
+add_flag('project', 'cloud-android-testing')
+
+# Signaling server info
+add_flag('sig_server_addr', '127.0.0.1')
+add_flag('sig_server_port', '8443')
+
+args = parser.parse_args()
+
+
+# Get GCE Driver
+ComputeEngine = get_driver(Provider.GCE)
+driver = ComputeEngine('', '',
+                       datacenter=args.datacenter, project=args.project)
+
+
+# Gets original base image from disk labels
+def get_base_image_from_labels(user_disk):
+    labels = ['cf_version', 'branch', 'target', 'build_id']
+    disk_labels = user_disk.extra['labels']
+
+    if all(label in disk_labels for label in labels):
+        cf_version = disk_labels['cf_version']
+        branch = disk_labels['branch']
+        target = disk_labels['target']
+        build_id = disk_labels['build_id']
+
+        base_image = f'halyard-{cf_version}-{branch}-{target}-{build_id}'
+        return base_image
+    else:
+        utils.fatal_error(f'Labels for {user_disk.name} are not complete.\n \
+            Must have all labels in: {labels}')
+
+# Sets disk labels with base image version data
+def set_base_image_labels(user_disk, img_name, branch, target):
+    dashes = [i for i, c in enumerate(img_name) if c=='-']
+    cf_version = img_name[dashes[0]+1:dashes[3]]
+    build_id = img_name[dashes[-1]+1:]
+
+    driver.ex_set_volume_labels(user_disk,
+        {'cf_version': cf_version, 'branch': branch,
+         'target': target, 'build_id': build_id})
+
+
+# SETUP
+
+# Set global vars
+args.target = args.target.replace('_','-')
+instance_name = f'halyard-{args.user_id}'
+disk_name = f'halyard-user-{args.user_id}'
+image_family = f'halyard-{args.branch}-{args.target}'
+
+# Stops execution if instance already exists
+instance = utils.find_instance(driver, instance_name, args.zone)
+if instance:
+    utils.fatal_error(f'Instance {instance_name} already exists.')
+
+# Looks for existing user disk
+user_disk = utils.find_disk(driver, disk_name, args.zone)
+if user_disk:
+    base_image = get_base_image_from_labels(user_disk)
+else:
+    user_disk = driver.create_volume(
+        30, disk_name, location=args.zone, image='halyard-blank')
+    base_image = None
+
+
+# CREATE INSTANCE
+
+# If existing user, use original base image
+if base_image:
+    try:
+        driver.ex_get_image(base_image)
+    except:
+        utils.fatal_error(f'Image {base_image} does not exist.\n \
+            New base images can be created using the `create_base_image` endpoint.')
+
+    new_instance = driver.create_node(
+        instance_name,
+        'n1-standard-4',
+        base_image,
+        location=args.zone,
+        ex_service_accounts=[{'scopes': ['storage-ro']}],
+        ex_disk_size=30,
+        ex_tags=args.tags)
+
+# If new user, use image family
+else:
+    try:
+        img = driver.ex_get_image_from_family(image_family)
+    except:
+        utils.fatal_error(f'Image in family {args.image_family} does not exist.\n \
+            New base images can be created using the `create_base_image` endpoint.')
+
+    set_base_image_labels(user_disk, img.name, args.branch, args.target)
+
+    new_instance = driver.create_node(
+        instance_name,
+        'n1-standard-4',
+        None,
+        location=args.zone,
+        ex_image_family=image_family,
+        ex_service_accounts=[{'scopes': ['storage-ro']}],
+        ex_disk_size=30,
+        ex_tags=args.tags)
+
+
+# ATTACH USER DISK AND LAUNCH
+
+utils.wait_for_instance(instance_name, args.zone)
+print('successfully created new instance', instance_name)
+
+driver.attach_volume(
+    new_instance,
+    user_disk)
+
+os.system(f'gcloud compute ssh --zone={args.zone} {instance_name} -- \
+    sudo mkdir /mnt/user_data')
+os.system(f'gcloud compute ssh --zone={args.zone} {instance_name} -- \
+    sudo mount /dev/sdb /mnt/user_data')
+
+os.system(f'gcloud compute ssh --zone={args.zone} {instance_name} -- \
+    HOME=/usr/local/share/cuttlefish /usr/local/share/cuttlefish/bin/launch_cvd \
+    --start_webrtc --daemon \
+    --webrtc_sig_server_addr={args.sig_server_addr} \
+    --webrtc_sig_server_port={args.sig_server_port} \
+    --start_webrtc_sig_server=false \
+    --webrtc_device_id={instance_name} \
+    --data_image=/mnt/user_data/userdata.img \
+    --data_policy=create_if_missing --blank_data_image_mb=30000')
+
+print('launched cuttlefish on', instance_name)


### PR DESCRIPTION
Fixes #13, fixes #16 
When a user id is registered in an existing `user_disk`, use this data to create a new instance with the same version it originally ran with. This endpoint is a combination of the `create_instance` and `resume_instance`.

## Features Added

- Created shared utils library and moved common functions there
- Can read an existing user disk and use its `disk_labels` to create an instance with the original image version.
- Resumes or creates (if not existing) the `user_data.img` file in mounted user_disk when launching the CVD.