### PR TITLE
Fetch build aritfacts directly on mounted disk

### DIFF
--- a/create_base_image/create_base_image.py
+++ b/create_base_image/create_base_image.py
@@ -139,7 +139,10 @@ driver.attach_volume(
     build_node,
     build_volume)
 
-os.system(f'gcloud compute scp create_base_image_gce.sh {args.build_instance}: \
+src_files = ['create_base_image_gce.sh', 'download_artifacts.sh']
+src = ' '.join(list(map(str,src_files)))
+
+os.system(f'gcloud compute scp {src} {args.build_instance}: \
     --zone={args.build_zone}')
 
 

--- a/create_base_image/create_base_image_hostlib.sh
+++ b/create_base_image/create_base_image_hostlib.sh
@@ -90,7 +90,7 @@ main() {
     build_tags=()
   fi
 
-  source_files=("create_base_image_gce.sh")
+  source_files=("create_base_image_gce.sh" "download_artifacts.sh")
 
   # Deletes instances and disks with names that will be used for build
   gcloud compute instances delete -q \

--- a/create_base_image/download_artifacts.sh
+++ b/create_base_image/download_artifacts.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+ 
+target="$1"
+build_id="$2"
+
+FETCH_ARTIFACTS="$(mktemp)"
+curl "https://www.googleapis.com/android/internal/build/v3/builds/$build_id/$target/attempts/latest/artifacts/fetch_cvd?alt=media" -o $FETCH_ARTIFACTS
+chmod +x $FETCH_ARTIFACTS
+exec $FETCH_ARTIFACTS


### PR DESCRIPTION
Fixes #11 
When creating a new base image the Android build artifacts are downloaded into the mounted disk where the image is being built.
Instead of having a function execute the fetcher script from the host machine, the code that downloads the fetcher was extracted into another script that is run directly on the mounted disk, to fix the `fetcher_config.json` locations.

## Features Added

- Extract function that downloads fetcher executable into separate script.
- Obtain build artifacts in root of mounted disk where new image is being built