### PR TITLE
Operator and device interface

### DIFF
--- a/instance/node_manager.py
+++ b/instance/node_manager.py
@@ -63,9 +63,8 @@ def set_base_image_labels(driver, user_disk, img_name, branch, target):
 
 
 def create_or_restore_instance(driver,
-        user_id='00001', zone='us-central1-b', tags=[],
-        branch='aosp-master', target='aosp_cf_x86_phone-userdebug',
-        sig_server_addr='10.128.0.45', sig_server_port='8443'):
+        user_id, sig_server_addr, sig_server_port, zone='us-central1-b',
+        tags=[], branch='aosp-master', target='aosp_cf_x86_phone-userdebug'):
     """Restores instance with existing user disk and original base image.
        Creates a new instance with latest image if user disk doesn't exist.
        Stores runtime data in external GCP disk.
@@ -150,11 +149,9 @@ def create_or_restore_instance(driver,
 
     return {"name": instance_name}
 
-
 def create_instance(driver,
-        user_id='00001', zone='us-central1-b', tags=[],
-        branch='aosp-master', target='aosp_cf_x86_phone-userdebug',
-        sig_server_addr='10.128.0.45', sig_server_port='8443'):
+        user_id, sig_server_addr, sig_server_port, zone='us-central1-b',
+        tags=[], branch='aosp-master', target='aosp_cf_x86_phone-userdebug'):
     """Creates a new Cuttlefish instance and launches it.
        Does not store runtime data in external GCP disk."""
 

--- a/instance/node_manager.py
+++ b/instance/node_manager.py
@@ -29,7 +29,7 @@ def delete_node(driver, instance_name, zone):
         driver.destroy_node(node)
         return {"stopped_instance": instance_name}
     else:
-        return {"error": "node not found"}
+        return {"error": f"instance {instance_name} not found"}
 
 
 def get_base_image_from_labels(user_disk):
@@ -68,7 +68,7 @@ def create_or_restore_instance(driver,
         sig_server_addr='10.128.0.45', sig_server_port='8443'):
     """Restores instance with existing user disk and original base image.
        Creates a new instance with latest image if user disk doesn't exist.
-       Stores userdata.img in external GCP disk.
+       Stores runtime data in external GCP disk.
        Launches Cuttlefish if creation is successful."""
 
     # SETUP
@@ -135,16 +135,15 @@ def create_or_restore_instance(driver,
     utils.wait_for_instance(instance_name, zone)
     print('successfully created new instance', instance_name)
 
-    driver.attach_volume(
-        new_instance,
-        user_disk)
+    driver.attach_volume(new_instance, user_disk)
+    print(f'attached {disk_name} to {instance_name}')
 
     os.system(f'gcloud compute ssh --zone={zone} {instance_name} -- \
         sudo mkdir /mnt/user_data')
     os.system(f'gcloud compute ssh --zone={zone} {instance_name} -- \
         sudo mount /dev/sdb /mnt/user_data')
     os.system(f'gcloud compute ssh --zone={zone} {instance_name} -- \
-        sudo chmod 777 /mnt/user_data/userdata.img')
+        sudo chmod -R 777 /mnt/user_data')
     # FIXME : should assign specific user permissions
 
     launch_cvd(instance_name, zone, sig_server_addr, sig_server_port)
@@ -157,7 +156,7 @@ def create_instance(driver,
         branch='aosp-master', target='aosp_cf_x86_phone-userdebug',
         sig_server_addr='10.128.0.45', sig_server_port='8443'):
     """Creates a new Cuttlefish instance and launches it.
-       Does not store userdata.img in external GCP disk."""
+       Does not store runtime data in external GCP disk."""
 
     target = target.replace('_','-')
     instance_name = f'halyard-{user_id}'
@@ -192,22 +191,29 @@ def create_instance(driver,
 
     return {"name": instance_name}
 
-def launch_cvd(instance_name, zone, sig_server_addr, sig_server_port, use_user_data=True):
+def launch_cvd(instance_name, zone, sig_server_addr, sig_server_port, use_user_disk=True):
     """Launch cvd on given instance and connect to operator on given address.
-       If use_user_data is True it uses existing user data disk."""
+       If use_user_disk is True it uses existing user data disk."""
 
-    launch_command = f'gcloud compute ssh --zone={zone} {instance_name} -- \
-        HOME=/usr/local/share/cuttlefish /usr/local/share/cuttlefish/bin/launch_cvd \
+    cuttlefish_dir = '/usr/local/share/cuttlefish'
+    user_data_dir = '/mnt/user_data'
+
+    launch_command = f'gcloud compute ssh --zone={zone} {instance_name} -- '
+
+    if use_user_disk:
+        launch_command += f'HOME={user_data_dir} \
+            ANDROID_HOST_OUT={cuttlefish_dir} \
+            ANDROID_PRODUCT_OUT={cuttlefish_dir} '
+    else:
+        launch_command += f'HOME={cuttlefish_dir} '
+
+    launch_command += f'{cuttlefish_dir}/bin/launch_cvd \
         --start_webrtc --daemon \
         --webrtc_sig_server_addr={sig_server_addr} \
         --webrtc_sig_server_port={sig_server_port} \
         --start_webrtc_sig_server=false \
         --webrtc_device_id={instance_name} \
         --report_anonymous_usage_stats=y'
-
-    if use_user_data:
-        launch_command += ' --data_image=/mnt/user_data/userdata.img \
-            --data_policy=create_if_missing --blank_data_image_mb=30000'
 
     os.system(launch_command)
 

--- a/instance/node_manager.py
+++ b/instance/node_manager.py
@@ -65,7 +65,7 @@ def set_base_image_labels(driver, user_disk, img_name, branch, target):
 def create_or_restore_instance(driver,
         user_id='00001', zone='us-central1-b', tags=[],
         branch='aosp-master', target='aosp_cf_x86_phone-userdebug',
-        sig_server_addr='127.0.0.1', sig_server_port='8443'):
+        sig_server_addr='10.128.0.45', sig_server_port='8443'):
     """Restores instance with existing user disk and original base image.
        Creates a new instance with latest image if user disk doesn't exist.
        Stores userdata.img in external GCP disk.
@@ -155,7 +155,7 @@ def create_or_restore_instance(driver,
 def create_instance(driver,
         user_id='00001', zone='us-central1-b', tags=[],
         branch='aosp-master', target='aosp_cf_x86_phone-userdebug',
-        sig_server_addr='127.0.0.1', sig_server_port='8443'):
+        sig_server_addr='10.128.0.45', sig_server_port='8443'):
     """Creates a new Cuttlefish instance and launches it.
        Does not store userdata.img in external GCP disk."""
 

--- a/main.py
+++ b/main.py
@@ -99,6 +99,7 @@ api.add_resource(Disk, "/disk/<string:disk_name>")
 # Demo UI Endpoints
 
 BASE = "http://127.0.0.1:5000/"
+OPERATOR_HOST = 'localhost:8443'
 
 @app.route('/')
 def index():
@@ -110,16 +111,26 @@ def index():
 def instances_page():
     instances = requests.get(BASE + "instance-list").json()['instances']
     disks = requests.get(BASE + "disk-list").json()['disks']
-    return render_template('instances.html', instances=instances, disks=disks)
+    return render_template('instances.html',
+        instances=instances, disks=disks, operator_host=OPERATOR_HOST)
 
 @app.route('/images')
 def images_page():
     images = requests.get(BASE + "image-list").json()['images']
     return render_template('images.html', images=images)
 
-@app.route('/instance/connect/<string:instance_name>')
-def enter_instance(instance_name):
-    return {'connect': instance_name}
+@app.route('/connect')
+def enter_instance():
+    args = request.args
+    if not 'device_id' in args:
+        return 'missing device_id in query params'
+    if not 'operator_host' in args:
+        return 'missing host in query params'
+    data = {}
+    data['device_id'] = args['device_id']
+    data['operator_host'] = args['operator_host']
+
+    return render_template('operator.html', data=data)
 
 if __name__ == '__main__':
     app.run(debug=True, use_reloader=False)

--- a/main.py
+++ b/main.py
@@ -99,7 +99,7 @@ api.add_resource(Disk, "/disk/<string:disk_name>")
 # Demo UI Endpoints
 
 BASE = "http://127.0.0.1:5000/"
-OPERATOR_HOST = 'localhost:8443'
+SIG_SERVER_HOST = "localhost:8443"
 
 @app.route('/')
 def index():
@@ -112,7 +112,7 @@ def instances_page():
     instances = requests.get(BASE + "instance-list").json()['instances']
     disks = requests.get(BASE + "disk-list").json()['disks']
     return render_template('instances.html',
-        instances=instances, disks=disks, operator_host=OPERATOR_HOST)
+        instances=instances, disks=disks)
 
 @app.route('/images')
 def images_page():
@@ -124,11 +124,9 @@ def enter_instance():
     args = request.args
     if not 'device_id' in args:
         return 'missing device_id in query params'
-    if not 'operator_host' in args:
-        return 'missing host in query params'
     data = {}
     data['device_id'] = args['device_id']
-    data['operator_host'] = args['operator_host']
+    data['sig_server_host'] = SIG_SERVER_HOST
 
     return render_template('operator.html', data=data)
 

--- a/server.py
+++ b/server.py
@@ -33,8 +33,10 @@ class Client:
 
     def send_device_info(self):
         client_ws = self.ws
-        device_info = self.device.device_info
-        send_data_ws(client_ws, device_info)
+        device_info_msg = {}
+        device_info_msg['message_type'] = 'device_info'
+        device_info_msg['device_info'] = self.device.device_info
+        send_data_ws(client_ws, device_info_msg)
     
     def forward_client_message(self, message):
         device_ws = self.device.ws

--- a/server.py
+++ b/server.py
@@ -39,7 +39,7 @@ class Client:
     def forward_client_message(self, message):
         device_ws = self.device.ws
         client_msg = {}
-        client_msg['type'] = 'client_msg'
+        client_msg['message_type'] = 'client_msg'
         client_msg['client_id'] = self.client_id
         client_msg['payload'] = message['payload']
         send_data_ws(device_ws, client_msg)
@@ -76,14 +76,14 @@ class Client:
             print(f'Forwarded message from client {self.client_id} to device {self.device.device_id}.')
 
     def process_request(self, message):
-        if 'type' not in message:
-            send_error('Missing message type')
-        elif message['type'] == 'connect':
+        if 'message_type' not in message:
+            send_error('Missing field message_type')
+        elif message['message_type'] == 'connect':
             self.handle_connect(message)
-        elif message['type'] == 'forward':
+        elif message['message_type'] == 'forward':
             self.handle_forward(message)
         else:
-            send_error(f'Unknown message type: {message["type"]}')
+            send_error(f'Unknown message type: {message["message_type"]}')
 
 
 class Device:
@@ -100,7 +100,7 @@ class Device:
         client_id = message['client_id']
         client_ws = self.clients[client_id].ws
         device_msg = {}
-        device_msg['type'] = 'device_msg'
+        device_msg['message_type'] = 'device_msg'
         device_msg['payload'] = message['payload']
         send_data_ws(client_ws, device_msg)
 
@@ -138,14 +138,14 @@ class Device:
             print(f'Forwarded message from device {self.device_id} to client {client_id}.')
 
     def process_request(self, message):
-        if 'type' not in message:
-            send_error('Missing message type')
-        elif message['type'] == 'register':
+        if 'message_type' not in message:
+            send_error('Missing field message_type')
+        elif message['message_type'] == 'register':
             self.handle_registration(message)
-        elif message['type'] == 'forward':
+        elif message['message_type'] == 'forward':
             self.handle_forward(message)
         else:
-            send_error(f'Unknown message type: {message["type"]}')
+            send_error(f'Unknown message type: {message["message_type"]}')
 
     def register_client(self, client):
         client_id = str(self.client_number)

--- a/server.py
+++ b/server.py
@@ -150,7 +150,7 @@ class Device:
             send_error(f'Unknown message type: {message["message_type"]}')
 
     def register_client(self, client):
-        client_id = str(self.client_number)
+        client_id = self.client_number
         client.client_id = client_id
         self.clients[client_id] = client
         self.client_number += 1

--- a/server.py
+++ b/server.py
@@ -162,25 +162,21 @@ class Device:
 def register_device(ws):
     print('ws connected to /register_device')
     device = Device(ws)
-    while not ws.closed:
-        raw_message = ws.receive()
-        message = json.loads(raw_message)
-        device.process_request(message)
-    if device.device_id:
-        devices.pop(device.device_id)
+        while not ws.closed:
+            raw_message = ws.receive()
+            message = json.loads(raw_message)
+            device.process_request(message)
+        if device.device_id:
+            devices.pop(device.device_id)
 
 @sockets.route('/connect_client')
 def connect_client(ws):
     print('ws connected to /connect_client')
     client = Client(ws)
-    while not ws.closed:
-        raw_message = ws.receive()
-        message = json.loads(raw_message)
-        client.process_request(message)
-    if client.device:
+        while not ws.closed:
+            raw_message = ws.receive()
+            message = json.loads(raw_message)
+            client.process_request(message)
+        if client.device:
         device_id = client.device.device_id
         devices[device_id].unregister_client(client.client_id)
-
-@app.route('/')
-def hello():
-    return 'Hello World'

--- a/server.py
+++ b/server.py
@@ -1,0 +1,201 @@
+from flask import Flask
+from flask_sockets import Sockets
+import json
+
+app = Flask(__name__)
+sockets = Sockets(app)
+
+devices = {} # A dictionary of id to devices
+
+SERVER_CONFIG = {"ice_servers": [{"urls":["stun:stun.l.google.com:19302"]}],
+                 "message_type": "config"}
+
+def send_error(msg):
+    print('ERROR -', msg)
+
+def send_server_config(ws):
+    config_json = json.dumps(SERVER_CONFIG)
+    ws.send(config_json)
+
+def send_data_ws(ws, data):
+    data_json = json.dumps(data)
+    ws.send(data_json)
+
+class Client:
+    """Client class for users that connect to devices"""
+
+    client_id = None
+    device = None
+    ws = None
+
+    def __init__(self, ws):
+        self.ws = ws
+
+    def send_device_info(self):
+        client_ws = self.ws
+        device_info = self.device.device_info
+        send_data_ws(client_ws, device_info)
+    
+    def forward_client_message(self, message):
+        device_ws = self.device.ws
+        client_msg = {}
+        client_msg['type'] = 'client_msg'
+        client_msg['client_id'] = self.client_id
+        client_msg['payload'] = message['payload']
+        send_data_ws(device_ws, client_msg)
+
+    def handle_connect(self, message):
+        """Connects client user to device"""
+        
+        if 'device_id' not in message:
+            send_error('Missing device_id field.')
+            return
+
+        device_id = message['device_id']        
+        if self.client_id:
+            send_error('Attempt to connect to multiple devices over same websocket.')
+        else:
+            send_server_config(self.ws)
+            if device_id not in devices:
+                send_error(f'Device id {device_id} not registered.')
+            else:
+                self.device = devices[device_id]
+                self.device.register_client(self)
+                print(f'Connected client {self.client_id} to device {self.device.device_id}.')
+                self.send_device_info()
+
+    def handle_forward(self, message):
+        """Handle forward for client"""
+
+        if not self.client_id:
+            send_error('No device associated to client.')
+        elif 'payload' not in message:
+            send_error('Missing payload field.')
+        else:
+            self.forward_client_message(message)
+            print(f'Forwarded message from client {self.client_id} to device {self.device.device_id}.')
+
+    def process_request(self, message):
+        if 'type' not in message:
+            send_error('Missing message type')
+        elif message['type'] == 'connect':
+            self.handle_connect(message)
+        elif message['type'] == 'forward':
+            self.handle_forward(message)
+        else:
+            send_error(f'Unknown message type: {message["type"]}')
+
+
+class Device:
+
+    client_number = 1
+    device_id = None
+    device_info = None
+    clients = {}
+
+    def __init__(self, ws):
+        self.ws = ws
+
+    def forward_device_message(self, message):
+        client_id = message['client_id']
+        client_ws = self.clients[client_id].ws
+        device_msg = {}
+        device_msg['type'] = 'device_msg'
+        device_msg['payload'] = message['payload']
+        send_data_ws(client_ws, device_msg)
+
+    def handle_registration(self, message):
+        """Registers device id and info in device list and sends config"""
+
+        if 'device_id' not in message:
+            send_error('Missing device id in registration request')
+            return
+
+        device_id = message['device_id']
+        if message['device_id'] in devices:
+            send_error(f'Device with id {device_id} already exists.')
+        elif 'device_info' not in message:
+            send_error('Missing device info in registration request.')
+        else:
+            devices[device_id] = self
+            self.device_id = device_id
+            self.device_info = message['device_info']
+            send_server_config(self.ws)
+            print(f'Registered device with id {device_id}')
+
+    def handle_forward(self, message):
+        """Handles forward for device"""
+
+        if 'client_id' not in message:
+            send_error('Missing client id in forward message.')
+        elif 'payload' not in message:
+            send_error('Missing payload field in forward message.')
+        elif message['client_id'] not in self.clients:
+            send_error(f'Unregistered client id {message["client_id"]}.')
+        else:
+            client_id = message['client_id']
+            self.forward_device_message(message)
+            print(f'Forwarded message from device {self.device_id} to client {client_id}.')
+
+    def process_request(self, message):
+        if 'type' not in message:
+            send_error('Missing message type')
+        elif message['type'] == 'register':
+            self.handle_registration(message)
+        elif message['type'] == 'forward':
+            self.handle_forward(message)
+        else:
+            send_error(f'Unknown message type: {message["type"]}')
+
+    def register_client(self, client):
+        client_id = str(self.client_number)
+        client.client_id = client_id
+        self.clients[client_id] = client
+        self.client_number += 1
+
+    def unregister_client(self, client_id):
+        self.clients.pop(client_id)
+
+@sockets.route('/register_device')
+def register_device(ws):
+    print('ws connected to /register_device')
+    device = Device(ws)
+    while not ws.closed:
+        raw_message = ws.receive()
+        message = json.loads(raw_message)
+        device.process_request(message)
+    if device.device_id:
+        devices.pop(device.device_id)
+
+@sockets.route('/connect_client')
+def connect_client(ws):
+    print('ws connected to /connect_client')
+    client = Client(ws)
+    while not ws.closed:
+        raw_message = ws.receive()
+        message = json.loads(raw_message)
+        client.process_request(message)
+    if client.device:
+        device_id = client.device.device_id
+        devices[device_id].unregister_client(client.client_id)
+
+@app.route('/')
+def hello():
+    return 'Hello World'
+
+# Add the static files:
+# * index.html
+# * js/app.js
+# * js/cf_webrtc.js
+# * style.css
+# * js/logcat.js?
+
+if __name__ == "__main__":
+    # You need gevent to be able to use websockets
+    # To run the app execute this: gunicorn -k flask_sockets.worker server:app
+    # Flask-Socket needs to be installed through pip (more details in
+    # https://github.com/heroku-python/flask-sockets)
+    from gevent import pywsgi
+    from geventwebsocket.handler import WebSocketHandler
+    server = pywsgi.WSGIServer(('', 8443), app, handler_class=WebSocketHandler)
+    server.serve_forever()

--- a/server.py
+++ b/server.py
@@ -182,20 +182,3 @@ def connect_client(ws):
 @app.route('/')
 def hello():
     return 'Hello World'
-
-# Add the static files:
-# * index.html
-# * js/app.js
-# * js/cf_webrtc.js
-# * style.css
-# * js/logcat.js?
-
-if __name__ == "__main__":
-    # You need gevent to be able to use websockets
-    # To run the app execute this: gunicorn -k flask_sockets.worker server:app
-    # Flask-Socket needs to be installed through pip (more details in
-    # https://github.com/heroku-python/flask-sockets)
-    from gevent import pywsgi
-    from geventwebsocket.handler import WebSocketHandler
-    server = pywsgi.WSGIServer(('', 8443), app, handler_class=WebSocketHandler)
-    server.serve_forever()

--- a/server.py
+++ b/server.py
@@ -160,21 +160,27 @@ class Device:
 def register_device(ws):
     print('ws connected to /register_device')
     device = Device(ws)
+    try:
         while not ws.closed:
             raw_message = ws.receive()
             message = json.loads(raw_message)
             device.process_request(message)
+    except:
         if device.device_id:
             devices.pop(device.device_id)
+            print(f'deleted device {device.device_id} from device list.')
 
 @sockets.route('/connect_client')
 def connect_client(ws):
     print('ws connected to /connect_client')
     client = Client(ws)
+    try:
         while not ws.closed:
             raw_message = ws.receive()
             message = json.loads(raw_message)
             client.process_request(message)
+    except:
         if client.device:
-        device_id = client.device.device_id
-        devices[device_id].unregister_client(client.client_id)
+            device_id = client.device.device_id
+            devices[device_id].unregister_client(client.client_id)
+            print(f'unregistered client {client.client_id} from device {device_id}')

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function ConnectToDevice(device_id) {
+  console.log('ConnectToDevice ', device_id);
+  const keyboardCaptureButton = document.getElementById('keyboardCaptureBtn');
+  keyboardCaptureButton.addEventListener('click', onKeyboardCaptureClick);
+
+  const deviceScreen = document.getElementById('deviceScreen');
+  deviceScreen.addEventListener('click', onInitialClick);
+
+  function onInitialClick(e) {
+    // This stupid thing makes sure that we disable controls after the first
+    // click... Why not just disable controls altogether you ask? Because then
+    // audio won't play because these days user-interaction is required to enable
+    // audio playback...
+    console.log('onInitialClick');
+
+    deviceScreen.controls = false;
+    deviceScreen.removeEventListener('click', onInitialClick);
+  }
+
+  let videoStream;
+  let display_label;
+  let mouseIsDown = false;
+  let deviceConnection;
+
+  let logcatBtn = document.getElementById('showLogcatBtn');
+  logcatBtn.onclick = ev => {
+    init_logcat(deviceConnection);
+    logcatBtn.remove();
+  };
+
+  function createControlPanelButton(command, title, icon_name) {
+    let button = document.createElement('button');
+    document.getElementById('control_panel').appendChild(button);
+    button.title = title;
+    button.dataset.command = command;
+    // Capture mousedown/up/out commands instead of click to enable
+    // hold detection. mouseout is used to catch if the user moves the
+    // mouse outside the button while holding down.
+    button.addEventListener('mousedown', onControlPanelButton);
+    button.addEventListener('mouseup', onControlPanelButton);
+    button.addEventListener('mouseout', onControlPanelButton);
+    // Set the button image using Material Design icons.
+    // See http://google.github.io/material-design-icons
+    // and https://material.io/resources/icons
+    button.classList.add('material-icons');
+    button.innerHTML = icon_name;
+  }
+  createControlPanelButton('power', 'Power', 'power_settings_new');
+  createControlPanelButton('home', 'Home', 'home');
+  createControlPanelButton('menu', 'Menu', 'menu');
+  createControlPanelButton('volumemute', 'Volume Mute', 'volume_mute');
+  createControlPanelButton('volumedown', 'Volume Down', 'volume_down');
+  createControlPanelButton('volumeup', 'Volume Up', 'volume_up');
+
+  let options = {
+    wsUrl: ((location.protocol == 'http:') ? 'ws://' : 'wss://') +
+      location.host + '/connect_client',
+  };
+
+  import('./cf_webrtc.js')
+    .then(webrtcModule => webrtcModule.Connect(device_id, options))
+    .then(devConn => {
+      deviceConnection = devConn;
+      // TODO(b/143667633): get multiple display configuration from the
+      // description object
+      console.log(deviceConnection.description);
+      let stream_id = devConn.description.displays[0].stream_id;
+      devConn.getStream(stream_id).then(stream => {
+        videoStream = stream;
+        display_label = stream_id;
+        deviceScreen.srcObject = videoStream;
+      }).catch(e => console.error('Unable to get display stream: ', e));
+      startMouseTracking();  // TODO stopMouseTracking() when disconnected
+      // TODO(b/163080005): Call updateDeviceDetails for any dynamic device
+      // details that may change after this initial connection.
+      updateDeviceDetails(deviceConnection.description);
+  });
+
+  function updateDeviceDetails(deviceInfo) {
+    if (deviceInfo.hardware) {
+      let cpus = deviceInfo.hardware.cpus;
+      let memory_mb = deviceInfo.hardware.memory_mb;
+      updateDeviceDetails.hardwareDetails =
+          `CPUs - ${cpus}\nDevice RAM - ${memory_mb}mb`;
+    }
+    if (deviceInfo.displays) {
+      let dpi = deviceInfo.displays[0].dpi;
+      let x_res = deviceInfo.displays[0].x_res;
+      let y_res = deviceInfo.displays[0].y_res;
+      updateDeviceDetails.displayDetails =
+          `Display - ${x_res}x${y_res} (${dpi}DPI)`;
+    }
+    document.getElementById('device_details_hardware').textContent = [
+        updateDeviceDetails.hardwareDetails,
+        updateDeviceDetails.displayDetails,
+    ].join('\n');
+  }
+  updateDeviceDetails.hardwareDetails = '';
+  updateDeviceDetails.displayDetails = '';
+
+  function onKeyboardCaptureClick(e) {
+    const selectedClass = 'selected';
+    if (keyboardCaptureButton.classList.contains(selectedClass)) {
+      stopKeyboardTracking();
+      keyboardCaptureButton.classList.remove(selectedClass);
+    } else {
+      startKeyboardTracking();
+      keyboardCaptureButton.classList.add(selectedClass);
+    }
+  }
+
+  function onControlPanelButton(e) {
+    if (e.type == 'mouseout' && e.which == 0) {
+      // Ignore mouseout events if no mouse button is pressed.
+      return;
+    }
+    deviceConnection.sendControlMessage(JSON.stringify({
+      command: e.target.dataset.command,
+      state: e.type == 'mousedown' ? "down" : "up",
+    }));
+  }
+
+  function startMouseTracking() {
+    if (window.PointerEvent) {
+      deviceScreen.addEventListener('pointerdown', onStartDrag);
+      deviceScreen.addEventListener('pointermove', onContinueDrag);
+      deviceScreen.addEventListener('pointerup', onEndDrag);
+    } else if (window.TouchEvent) {
+      deviceScreen.addEventListener('touchstart', onStartDrag);
+      deviceScreen.addEventListener('touchmove', onContinueDrag);
+      deviceScreen.addEventListener('touchend', onEndDrag);
+    } else if (window.MouseEvent) {
+      deviceScreen.addEventListener('mousedown', onStartDrag);
+      deviceScreen.addEventListener('mousemove', onContinueDrag);
+      deviceScreen.addEventListener('mouseup', onEndDrag);
+    }
+  }
+
+  function stopMouseTracking() {
+    if (window.PointerEvent) {
+      deviceScreen.removeEventListener('pointerdown', onStartDrag);
+      deviceScreen.removeEventListener('pointermove', onContinueDrag);
+      deviceScreen.removeEventListener('pointerup', onEndDrag);
+    } else if (window.TouchEvent) {
+      deviceScreen.removeEventListener('touchstart', onStartDrag);
+      deviceScreen.removeEventListener('touchmove', onContinueDrag);
+      deviceScreen.removeEventListener('touchend', onEndDrag);
+    } else if (window.MouseEvent) {
+      deviceScreen.removeEventListener('mousedown', onStartDrag);
+      deviceScreen.removeEventListener('mousemove', onContinueDrag);
+      deviceScreen.removeEventListener('mouseup', onEndDrag);
+    }
+  }
+
+  function startKeyboardTracking() {
+    document.addEventListener('keydown', onKeyEvent);
+    document.addEventListener('keyup', onKeyEvent);
+  }
+
+  function stopKeyboardTracking() {
+    document.removeEventListener('keydown', onKeyEvent);
+    document.removeEventListener('keyup', onKeyEvent);
+  }
+
+  function onStartDrag(e) {
+    e.preventDefault();
+
+    // console.log("mousedown at " + e.pageX + " / " + e.pageY);
+    mouseIsDown = true;
+
+    sendMouseUpdate(true, e);
+  }
+
+  function onEndDrag(e) {
+    e.preventDefault();
+
+    // console.log("mouseup at " + e.pageX + " / " + e.pageY);
+    mouseIsDown = false;
+
+    sendMouseUpdate(false, e);
+  }
+
+  function onContinueDrag(e) {
+    e.preventDefault();
+
+    // console.log("mousemove at " + e.pageX + " / " + e.pageY + ", down=" +
+    // mouseIsDown);
+    if (mouseIsDown) {
+      sendMouseUpdate(true, e);
+    }
+  }
+
+  function sendMouseUpdate(down, e) {
+    console.assert(deviceConnection, 'Can\'t send mouse update without device');
+    var x = e.offsetX;
+    var y = e.offsetY;
+
+    // Before the first video frame arrives there is no way to know width and
+    // height of the device's screen, so turn every click into a click at 0x0.
+    // A click at that position is not more dangerous than anywhere else since
+    // the user is clicking blind anyways.
+    const videoWidth = deviceScreen.videoWidth? deviceScreen.videoWidth: 1;
+    const videoHeight = deviceScreen.videoHeight? deviceScreen.videoHeight: 1;
+    const elementWidth = deviceScreen.offsetWidth? deviceScreen.offsetWidth: 1;
+    const elementHeight = deviceScreen.offsetHeight? deviceScreen.offsetHeight: 1;
+
+    // vh*ew > eh*vw? then scale h instead of w
+    const scaleHeight = videoHeight * elementWidth > videoWidth * elementHeight;
+    var elementScaling = 0, videoScaling = 0;
+    if (scaleHeight) {
+      elementScaling = elementHeight;
+      videoScaling = videoHeight;
+    } else {
+      elementScaling = elementWidth;
+      videoScaling = videoWidth;
+    }
+
+    // Substract the offset produced by the difference in aspect ratio if any.
+    if (scaleHeight) {
+      x -= (elementWidth - elementScaling * videoWidth / videoScaling) / 2;
+    } else {
+      y -= (elementHeight - elementScaling * videoHeight / videoScaling) / 2;
+    }
+
+    // Convert to coordinates relative to the video
+    x = videoScaling * x / elementScaling;
+    y = videoScaling * y / elementScaling;
+
+    deviceConnection.sendMousePosition(
+        {x: Math.trunc(x), y: Math.trunc(y), down, display_label});
+  }
+
+  function onKeyEvent(e) {
+    e.preventDefault();
+    console.assert(deviceConnection, 'Can\'t send key event without device');
+    deviceConnection.sendKeyEvent(e.code, e.type);
+  }
+}
+
+/******************************************************************************/
+
+function ConnectDeviceCb(dev_id) {
+  console.log('Connect: ' + dev_id);
+  // Hide the device selection screen
+  document.getElementById('device_selector').style.display = 'none';
+  // Show the device control screen
+  document.getElementById('device_connection').style.visibility = 'visible';
+  ConnectToDevice(dev_id);
+}
+
+function ShowNewDeviceList(device_ids) {
+  let ul = document.getElementById('device_list');
+  ul.innerHTML = "";
+  let count = 1;
+  for (const dev_id of device_ids) {
+    const button_id = 'connect_' + count++;
+    ul.innerHTML += ('<li class="device_entry" title="Connect to ' + dev_id
+                     + '">' + dev_id + '<button id="' + button_id
+                     + '" >Connect</button></li>');
+    document.getElementById(button_id).addEventListener(
+        'click', evt => ConnectDeviceCb(dev_id));
+  }
+}
+
+function UpdateDeviceList() {
+  let url = ((location.protocol == 'http:') ? 'ws:' : 'wss:') + location.host +
+    '/list_devices';
+  let ws = new WebSocket(url);
+  ws.onopen = () => {
+    ws.send("give me those device ids");
+  };
+  ws.onmessage = msg => {
+   let device_ids = JSON.parse(msg.data);
+    ShowNewDeviceList(device_ids);
+  };
+}
+
+// Get any devices that are already connected
+UpdateDeviceList();
+// Update the list at the user's request
+document.getElementById('refresh_list')
+    .addEventListener('click', evt => UpdateDeviceList());

--- a/static/app.js
+++ b/static/app.js
@@ -70,9 +70,9 @@ function ConnectToDevice(device_id) {
   createControlPanelButton('volumedown', 'Volume Down', 'volume_down');
   createControlPanelButton('volumeup', 'Volume Up', 'volume_up');
 
-  let options = {
+  let options = {      
     wsUrl: ((location.protocol == 'http:') ? 'ws://' : 'wss://') +
-      location.host + '/connect_client',
+      operator_host + '/connect_client',
   };
 
   import('./cf_webrtc.js')
@@ -266,35 +266,4 @@ function ConnectDeviceCb(dev_id) {
   ConnectToDevice(dev_id);
 }
 
-function ShowNewDeviceList(device_ids) {
-  let ul = document.getElementById('device_list');
-  ul.innerHTML = "";
-  let count = 1;
-  for (const dev_id of device_ids) {
-    const button_id = 'connect_' + count++;
-    ul.innerHTML += ('<li class="device_entry" title="Connect to ' + dev_id
-                     + '">' + dev_id + '<button id="' + button_id
-                     + '" >Connect</button></li>');
-    document.getElementById(button_id).addEventListener(
-        'click', evt => ConnectDeviceCb(dev_id));
-  }
-}
-
-function UpdateDeviceList() {
-  let url = ((location.protocol == 'http:') ? 'ws:' : 'wss:') + location.host +
-    '/list_devices';
-  let ws = new WebSocket(url);
-  ws.onopen = () => {
-    ws.send("give me those device ids");
-  };
-  ws.onmessage = msg => {
-   let device_ids = JSON.parse(msg.data);
-    ShowNewDeviceList(device_ids);
-  };
-}
-
-// Get any devices that are already connected
-UpdateDeviceList();
-// Update the list at the user's request
-document.getElementById('refresh_list')
-    .addEventListener('click', evt => UpdateDeviceList());
+ConnectDeviceCb(device_id);

--- a/static/app.js
+++ b/static/app.js
@@ -257,13 +257,4 @@ function ConnectToDevice(device_id) {
 
 /******************************************************************************/
 
-function ConnectDeviceCb(dev_id) {
-  console.log('Connect: ' + dev_id);
-  // Hide the device selection screen
-  document.getElementById('device_selector').style.display = 'none';
-  // Show the device control screen
-  document.getElementById('device_connection').style.visibility = 'visible';
-  ConnectToDevice(dev_id);
-}
-
-ConnectDeviceCb(device_id);
+ConnectToDevice(device_id);

--- a/static/app.js
+++ b/static/app.js
@@ -72,7 +72,7 @@ function ConnectToDevice(device_id) {
 
   let options = {      
     wsUrl: ((location.protocol == 'http:') ? 'ws://' : 'wss://') +
-      operator_host + '/connect_client',
+     sig_server_host + '/connect_client',
   };
 
   import('./cf_webrtc.js')

--- a/static/cf_webrtc.js
+++ b/static/cf_webrtc.js
@@ -1,0 +1,410 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function createDataChannel(pc, label, onMessage) {
+    console.log('creating data channel: ' + label);
+    let dataChannel = pc.createDataChannel(label);
+    // Return an object with a send function like that of the dataChannel, but
+    // that only actually sends over the data channel once it has connected.
+    return {
+      channelPromise: new Promise((resolve, reject) => {
+        dataChannel.onopen = (event) => {
+          resolve(dataChannel);
+        };
+        dataChannel.onclose = () => {
+          console.log(
+              'Data channel=' + label + ' state=' + dataChannel.readyState);
+        };
+        dataChannel.onmessage = onMessage ? onMessage : (msg) => {
+          console.log('Data channel=' + label + ' data="' + msg.data + '"');
+        };
+        dataChannel.onerror = err => {
+          reject(err);
+        };
+      }),
+      send: function(msg) {
+        this.channelPromise = this.channelPromise.then(channel => {
+          channel.send(msg);
+          return channel;
+        })
+      },
+    };
+  }
+  
+  function awaitDataChannel(pc, label, onMessage) {
+    console.log('expecting data channel: ' + label);
+    // Return an object with a send function like that of the dataChannel, but
+    // that only actually sends over the data channel once it has connected.
+    return {
+      channelPromise: new Promise((resolve, reject) => {
+        let prev_ondatachannel = pc.ondatachannel;
+        pc.ondatachannel = ev => {
+          let dataChannel = ev.channel;
+          if (dataChannel.label == label) {
+            dataChannel.onopen = (event) => {
+              resolve(dataChannel);
+            };
+            dataChannel.onclose = () => {
+              console.log(
+                  'Data channel=' + label + ' state=' + dataChannel.readyState);
+            };
+            dataChannel.onmessage = onMessage ? onMessage : (msg) => {
+              console.log('Data channel=' + label + ' data="' + msg.data + '"');
+            };
+            dataChannel.onerror = err => {
+              reject(err);
+            };
+          } else if (prev_ondatachannel) {
+            prev_ondatachannel(ev);
+          }
+        };
+      }),
+      send: function(msg) {
+        this.channelPromise = this.channelPromise.then(channel => {
+          channel.send(msg);
+          return channel;
+        })
+      },
+    };
+  }
+  
+  class DeviceConnection {
+    constructor(pc, control) {
+      this._pc = pc;
+      this._control = control;
+      this._inputChannel = createDataChannel(pc, 'input-channel');
+      this._adbChannel = createDataChannel(pc, 'adb-channel', (msg) => {
+        if (this._onAdbMessage) {
+          this._onAdbMessage(msg.data);
+        } else {
+          console.error('Received unexpected ADB message');
+        }
+      });
+      this._controlChannel = awaitDataChannel(pc, 'device-control', (msg) => {
+        if (this._onControlMessage) {
+          this._onControlMessage(msg);
+        } else {
+          console.error('Received unexpected ADB message');
+        }
+      });
+      this._streams = {};
+      this._streamPromiseResolvers = {};
+  
+      pc.addEventListener('track', e => {
+        console.log('Got remote stream: ', e);
+        for (const stream of e.streams) {
+          this._streams[stream.id] = stream;
+          if (this._streamPromiseResolvers[stream.id]) {
+            for (let resolver of this._streamPromiseResolvers[stream.id]) {
+              resolver();
+            }
+            delete this._streamPromiseResolvers[stream.id];
+          }
+        }
+      });
+    }
+  
+    set description(desc) {
+      this._description = desc;
+    }
+  
+    get description() {
+      return this._description;
+    }
+  
+    getStream(stream_id) {
+      return new Promise((resolve, reject) => {
+        if (this._streams[stream_id]) {
+          resolve(this._streams[stream_id]);
+        } else {
+          if (!this._streamPromiseResolvers[stream_id]) {
+            this._streamPromiseResolvers[stream_id] = [];
+          }
+          this._streamPromiseResolvers[stream_id].push(resolve);
+        }
+      });
+    }
+  
+    _sendJsonInput(evt) {
+      this._inputChannel.send(JSON.stringify(evt));
+    }
+  
+    sendMousePosition({x, y, down, display_label}) {
+      this._sendJsonInput({
+        type: 'mouse',
+        down: down ? 1 : 0,
+        x,
+        y,
+        display_label,
+      });
+    }
+  
+    // TODO (b/124121375): This should probably be an array of pointer events and
+    // have different properties.
+    sendMultiTouch({id, x, y, initialDown, slot, display_label}) {
+      this._sendJsonInput({
+        type: 'multi-touch',
+        id,
+        x,
+        y,
+        initialDown: initialDown ? 1 : 0,
+        slot,
+        display_label,
+      });
+    }
+  
+    sendKeyEvent(code, type) {
+      this._sendJsonInput({type: 'keyboard', keycode: code, event_type: type});
+    }
+  
+    disconnect() {
+      this._pc.close();
+    }
+  
+    // Sends binary data directly to the in-device adb daemon (skipping the host)
+    sendAdbMessage(msg) {
+      this._adbChannel.send(msg);
+    }
+  
+    // Provide a callback to receive data from the in-device adb daemon
+    onAdbMessage(cb) {
+      this._onAdbMessage = cb;
+    }
+  
+    // Send control commands to the device
+    sendControlMessage(msg) {
+      this._controlChannel.send(msg);
+    }
+  
+    // Provide a callback to receive control-related comms from the device
+    onControlMessage(cb) {
+      this._onControlMessage = cb;
+    }
+  }
+  
+  
+  class WebRTCControl {
+    constructor({
+      wsUrl = '',
+    }) {
+      /*
+       * Private attributes:
+       *
+       * _wsPromise: promises the underlying websocket, should resolve when the
+       *             socket passes to OPEN state, will be rejecte/replaced by a
+       *             rejected promise if an error is detected on the socket.
+       *
+       * _onOffer
+       * _onIceCandidate
+       */
+  
+      this._promiseResolvers = {};
+  
+      this._wsPromise = new Promise((resolve, reject) => {
+        let ws = new WebSocket(wsUrl);
+        ws.onopen = () => {
+          console.info(`Connected to ${wsUrl}`);
+          resolve(ws);
+        };
+        ws.onerror = evt => {
+          console.error('WebSocket error:', evt);
+          reject(evt);
+          // If the promise was already resolved the previous line has no effect
+          this._wsPromise = Promise.reject(new Error(evt));
+        };
+        ws.onmessage = e => {
+          let data = JSON.parse(e.data);
+          this._onWebsocketMessage(data);
+        };
+      });
+    }
+  
+    _onWebsocketMessage(message) {
+      const type = message.message_type;
+      if (message.error) {
+        console.error(message.error);
+        return;
+      }
+      switch (type) {
+        case 'config':
+          this._infra_config = message;
+          break;
+        case 'device_info':
+          if (this._on_device_available) {
+            this._on_device_available(message.device_info);
+            delete this._on_device_available;
+          } else {
+            console.error('Received unsolicited device info');
+          }
+          break;
+        case 'device_msg':
+          this._onDeviceMessage(message.payload);
+          break;
+        default:
+          console.error('Unrecognized message type from server: ', type);
+          console.error(message);
+      }
+    }
+  
+    _onDeviceMessage(message) {
+      let type = message.type;
+      switch (type) {
+        case 'offer':
+          if (this._onOffer) {
+            this._onOffer({type: 'offer', sdp: message.sdp});
+          } else {
+            console.error('Receive offer, but nothing is wating for it');
+          }
+          break;
+        case 'ice-candidate':
+          if (this._onIceCandidate) {
+            this._onIceCandidate(new RTCIceCandidate({
+              sdpMid: message.mid,
+              sdpMLineIndex: message.mLineIndex,
+              candidate: message.candidate
+            }));
+          } else {
+            console.error('Received ice candidate but nothing is waiting for it');
+          }
+          break;
+        default:
+          console.error('Unrecognized message type from device: ', type);
+      }
+    }
+  
+    async _wsSendJson(obj) {
+      let ws = await this._wsPromise;
+      return ws.send(JSON.stringify(obj));
+    }
+    async _sendToDevice(payload) {
+      this._wsSendJson({message_type: 'forward', payload});
+    }
+  
+    onOffer(cb) {
+      this._onOffer = cb;
+    }
+  
+    onIceCandidate(cb) {
+      this._onIceCandidate = cb;
+    }
+  
+    async requestDevice(device_id) {
+      return new Promise((resolve, reject) => {
+        this._on_device_available = (deviceInfo) => resolve({
+          deviceInfo,
+          infraConfig: this._infra_config,
+        });
+        this._wsSendJson({
+          message_type: 'connect',
+          device_id,
+        });
+      });
+    }
+  
+    ConnectDevice() {
+      console.log('ConnectDevice');
+      this._sendToDevice({type: 'request-offer'});
+    }
+  
+    /**
+     * Sends a remote description to the device.
+     */
+    async sendClientDescription(desc) {
+      console.log('sendClientDescription');
+      this._sendToDevice({type: 'answer', sdp: desc.sdp});
+    }
+  
+    /**
+     * Sends an ICE candidate to the device
+     */
+    async sendIceCandidate(candidate) {
+      this._sendToDevice({type: 'ice-candidate', candidate});
+    }
+  }
+  
+  function createPeerConnection(infra_config) {
+    let pc_config = {iceServers: []};
+    for (const stun of infra_config.ice_servers) {
+      pc_config.iceServers.push({urls: 'stun:' + stun});
+    }
+    let pc = new RTCPeerConnection(pc_config);
+  
+    pc.addEventListener('icecandidate', evt => {
+      console.log('Local ICE Candidate: ', evt.candidate);
+    });
+    pc.addEventListener('iceconnectionstatechange', evt => {
+      console.log(`ICE State Change: ${pc.iceConnectionState}`);
+    });
+    pc.addEventListener(
+        'connectionstatechange',
+        evt =>
+            console.log(`WebRTC Connection State Change: ${pc.connectionState}`));
+    return pc;
+  }
+  
+  export async function Connect(deviceId, options) {
+    let control = new WebRTCControl(options);
+    let requestRet = await control.requestDevice(deviceId);
+    let deviceInfo = requestRet.deviceInfo;
+    let infraConfig = requestRet.infraConfig;
+    console.log('Device available:');
+    console.log(deviceInfo);
+    let pc_config = {iceServers: []};
+    if (infraConfig.ice_servers && infraConfig.ice_servers.length > 0) {
+      for (const server of infraConfig.ice_servers) {
+        pc_config.iceServers.push(server);
+      }
+    }
+    let pc = createPeerConnection(infraConfig, control);
+    let deviceConnection = new DeviceConnection(pc, control);
+    deviceConnection.description = deviceInfo;
+    async function acceptOfferAndReplyAnswer(offer) {
+      try {
+        await pc.setRemoteDescription(offer);
+        let answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        await control.sendClientDescription(answer);
+      } catch (e) {
+        console.error('Error establishing WebRTC connection: ', e)
+        throw e;
+      }
+    }
+    control.onOffer(desc => {
+      console.log('Offer: ', desc);
+      acceptOfferAndReplyAnswer(desc);
+    });
+    control.onIceCandidate(iceCandidate => {
+      console.log(`Remote ICE Candidate: `, iceCandidate);
+      pc.addIceCandidate(iceCandidate);
+    });
+  
+    pc.addEventListener('icecandidate', evt => {
+      if (evt.candidate) control.sendIceCandidate(evt.candidate);
+    });
+    let connected_promise = new Promise((resolve, reject) => {
+      pc.addEventListener('connectionstatechange', evt => {
+        let state = pc.connectionState;
+        if (state == 'connected') {
+          resolve(deviceConnection);
+        } else if (state == 'failed') {
+          reject(evt);
+        }
+      });
+    });
+    control.ConnectDevice();
+  
+    return connected_promise;
+  }

--- a/static/logcat.js
+++ b/static/logcat.js
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let adb_ws;
+let logcat = document.getElementById('logcat');
+
+let utf8Encoder = new TextEncoder();
+let utf8Decoder = new TextDecoder();
+
+const A_CNXN = 0x4e584e43;
+const A_OPEN = 0x4e45504f;
+const A_WRTE = 0x45545257;
+const A_OKAY = 0x59414b4f;
+
+const kLocalChannelId = 666;
+
+let array = new Uint8Array();
+
+function setU32LE(array, offset, x) {
+    array[offset] = x & 0xff;
+    array[offset + 1] = (x >> 8) & 0xff;
+    array[offset + 2] = (x >> 16) & 0xff;
+    array[offset + 3] = x >> 24;
+}
+
+function getU32LE(array, offset) {
+    let x = array[offset]
+        | (array[offset + 1] << 8)
+        | (array[offset + 2] << 16)
+        | (array[offset + 3] << 24);
+
+    return x >>> 0;  // convert signed to unsigned if necessary.
+}
+
+function computeChecksum(array) {
+    let sum = 0;
+    let i;
+    for (i = 0; i < array.length; ++i) {
+        sum = ((sum + array[i]) & 0xffffffff) >>> 0;
+    }
+
+    return sum;
+}
+
+function createAdbMessage(command, arg0, arg1, payload) {
+    let arrayBuffer = new ArrayBuffer(24 + payload.length);
+    let array = new Uint8Array(arrayBuffer);
+    setU32LE(array, 0, command);
+    setU32LE(array, 4, arg0);
+    setU32LE(array, 8, arg1);
+    setU32LE(array, 12, payload.length);
+    setU32LE(array, 16, computeChecksum(payload));
+    setU32LE(array, 20, command ^ 0xffffffff);
+    array.set(payload, 24);
+
+    return arrayBuffer;
+}
+
+function adbOpenConnection() {
+    let systemIdentity = utf8Encoder.encode("Cray_II:1234:whatever");
+
+    let arrayBuffer = createAdbMessage(
+        A_CNXN, 0x1000000, 256 * 1024, systemIdentity);
+
+    adb_ws.send(arrayBuffer);
+}
+
+function adbOpenChannel() {
+    let destination = utf8Encoder.encode("shell:logcat");
+
+    let arrayBuffer = createAdbMessage(A_OPEN, kLocalChannelId, 0, destination);
+    adb_ws.send(arrayBuffer);
+}
+
+function adbSendOkay(remoteId) {
+    let payload = new Uint8Array(0);
+
+    let arrayBuffer = createAdbMessage(
+        A_OKAY, kLocalChannelId, remoteId, payload);
+
+    adb_ws.send(arrayBuffer);
+}
+
+function JoinArrays(arr1, arr2) {
+  let arr = new Uint8Array(arr1.length + arr2.length);
+  arr.set(arr1, 0);
+  arr.set(arr2, arr1.length);
+  return arr;
+}
+
+function adbOnMessage(arrayBuffer) {
+    // console.log("adb_ws: onmessage (" + arrayBuffer.byteLength + " bytes)");
+    array = JoinArrays(array, new Uint8Array(arrayBuffer));
+
+    while (array.length > 0) {
+        if (array.length < 24) {
+            // Incomplete package, must wait for more data.
+            return;
+        }
+
+        let command = getU32LE(array, 0);
+        let magic = getU32LE(array, 20);
+
+        if (command != ((magic ^ 0xffffffff) >>> 0)) {
+            console.log("command = " + command + ", magic = " + magic);
+            console.log("adb message command vs magic failed.");
+            return;
+        }
+
+        let payloadLength = getU32LE(array, 12);
+
+        if (array.length < 24 + payloadLength) {
+            // Incomplete package, must wait for more data.
+            return;
+        }
+
+        let payloadChecksum = getU32LE(array, 16);
+        let checksum = computeChecksum(array.slice(24));
+
+        if (payloadChecksum != checksum) {
+            console.log("adb message checksum mismatch.");
+            return;
+        }
+
+        switch (command) {
+            case A_CNXN:
+            {
+                console.log("connected.");
+
+                adbOpenChannel();
+                break;
+            }
+
+            case A_OKAY:
+            {
+                let remoteId = getU32LE(array, 4);
+                console.log("channel created w/ remoteId " + remoteId);
+                break;
+            }
+
+            case A_WRTE:
+            {
+                let payloadText = utf8Decoder.decode(array.slice(24));
+
+                // Limit to 100 lines
+                logcat.value = (logcat.value + payloadText).split('\n').slice(-100).join('\n');
+
+                // Scroll to bottom
+                logcat.scrollTop = logcat.scrollHeight;
+
+                let remoteId = getU32LE(array, 4);
+                adbSendOkay(remoteId);
+                break;
+            }
+        }
+        array = array.subarray(24 + payloadLength, array.length);
+    }
+}
+
+function init_logcat(devConn) {
+    adb_ws = {
+      send: function(buffer) {
+        devConn.sendAdbMessage(buffer);
+      }
+    };
+
+    logcat.style.display = "initial";
+    devConn.onAdbMessage(msg => adbOnMessage(msg));
+
+    adbOpenConnection();
+}

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -23,7 +23,7 @@ createNewInstance = function() {
     let url = 'instance-list'
     let type = 'POST'
     let body = {"tags": ["kradtke-ssh"]}
-    return ajax_call(msg, url, type, body)
+    return ajaxCall(msg, url, type, body)
 }
 
 infoInstance = function(instance_name) {
@@ -31,7 +31,7 @@ infoInstance = function(instance_name) {
     let url = 'instance/' + instance_name
     let type = 'GET'
     let body = {}
-    return ajax_call(msg, url, type, body)
+    return ajaxCall(msg, url, type, body)
 }
 
 stopInstance = function(instance_name) {
@@ -39,7 +39,7 @@ stopInstance = function(instance_name) {
     let url = 'instance/' + instance_name
     let type = 'DELETE'
     let body = {}
-    return ajax_call(msg, url, type, body)
+    return ajaxCall(msg, url, type, body)
 }
 
 // DISKS
@@ -50,7 +50,7 @@ restoreDisk = function(disk_name) {
     let url = 'instance-list'
     let type = 'POST'
     let body = {"user_id": user_id, "tags": ["kradtke-ssh"]}
-    return ajax_call(msg, url, type, body)
+    return ajaxCall(msg, url, type, body)
 }
 
 deleteDisk = function(disk_name) {
@@ -58,7 +58,7 @@ deleteDisk = function(disk_name) {
     let url = 'disk/' + disk_name
     let type = 'DELETE'
     let body = {}
-    return ajax_call(msg, url, type, body)
+    return ajaxCall(msg, url, type, body)
 }
 
 // IMAGES
@@ -68,7 +68,7 @@ createNewImage = function() {
     let url = 'image-list'
     let type = 'POST'
     let body = {"tags": ["kradtke-ssh"]}
-    return ajax_call(msg, url, type, body)
+    return ajaxCall(msg, url, type, body)
 }
 
 infoImage = function(image_name) {
@@ -76,7 +76,7 @@ infoImage = function(image_name) {
     let url = 'image/' + image_name
     let type = 'GET'
     let body = {}
-    return ajax_call(msg, url, type, body)
+    return ajaxCall(msg, url, type, body)
 }
 
 deleteImage = function(image_name) {
@@ -84,5 +84,5 @@ deleteImage = function(image_name) {
     let url = 'image/' + image_name
     let type = 'DELETE'
     let body = {}
-    return ajax_call(msg, url, type, body)
+    return ajaxCall(msg, url, type, body)
 }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -19,10 +19,11 @@ ajaxCall = function(msg, url, type, body) {
 // INSTANCES
 
 createNewInstance = function() {
+    var userId = document.getElementById("userIdInput").value;
     let msg = 'New Instance AJAX call'
     let url = 'instance-list'
     let type = 'POST'
-    let body = {"tags": ["kradtke-ssh"]}
+    let body = {"user_id": userId, "tags": ["kradtke-ssh"]}
     return ajaxCall(msg, url, type, body)
 }
 

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1,4 +1,7 @@
 
+const SIG_SERVER_ADDR = "10.128.0.45"
+const SIG_SERVER_PORT = "8443"
+
 ajaxCall = function(msg, url, type, body) {
     console.log(msg);
     return $.ajax({
@@ -23,7 +26,8 @@ createNewInstance = function() {
     let msg = 'New Instance AJAX call'
     let url = 'instance-list'
     let type = 'POST'
-    let body = {"user_id": userId, "tags": ["kradtke-ssh"]}
+    let body = {"user_id": userId, "sig_server_addr": SIG_SERVER_ADDR,
+                "sig_server_port": SIG_SERVER_PORT, "tags": ["kradtke-ssh"]}
     return ajaxCall(msg, url, type, body)
 }
 
@@ -46,11 +50,12 @@ stopInstance = function(instance_name) {
 // DISKS
 
 restoreDisk = function(disk_name) {
-    let user_id = disk_name.replace(/^(halyard-user-)/,"");
+    let userId = disk_name.replace(/^(halyard-user-)/,"");
     let msg = 'Restore Disk AJAX call'
     let url = 'instance-list'
     let type = 'POST'
-    let body = {"user_id": user_id, "tags": ["kradtke-ssh"]}
+    let body = {"user_id": userId, "sig_server_addr": SIG_SERVER_ADDR,
+                "sig_server_port": SIG_SERVER_PORT, "tags": ["kradtke-ssh"]}
     return ajaxCall(msg, url, type, body)
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -19,26 +19,6 @@
     margin: 0;
 }
 
-#device_selector {
-    color: whitesmoke;
-}
-#device_selector li.device_entry {
-    cursor: pointer;
-}
-
-#refresh_list {
-    cursor: pointer;
-}
-
-#device_list .device_entry button {
-    margin-left: 10px;
-}
-
-
-#device_connection {
-    visibility: hidden;
-}
-
 #device_connection button.selected {
     background-color: #aaaaaa;
     border-style: solid;

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ body {
+    background-color:black;
+    margin: 0;
+}
+
+#device_selector {
+    color: whitesmoke;
+}
+#device_selector li.device_entry {
+    cursor: pointer;
+}
+
+#refresh_list {
+    cursor: pointer;
+}
+
+#device_list .device_entry button {
+    margin-left: 10px;
+}
+
+
+#device_connection {
+    visibility: hidden;
+}
+
+#device_connection button.selected {
+    background-color: #aaaaaa;
+    border-style: solid;
+    border-color: #aaaaaa;
+}
+
+#control_view {
+    text-align: left;
+    padding: 10px;
+    min-width: 450px;
+}
+
+/* Screens >1000px place the device view on the left and the control
+ * view on the right. Other screens have deview view on top and control
+ * view on bottom. */
+@media screen and (min-width: 1000px) {
+    #device_view {
+        float: left;
+        height: 100vh;
+    }
+    #control_view {
+        float: left;
+    }
+}
+
+#deviceScreen {
+    max-width: 100%;
+    max-height: 100%;
+    touch-action: none;
+}
+
+#control_panel {
+    font-family: 'Open Sans', sans-serif;
+}
+
+#control_panel h2 {
+    color: white;
+}
+
+#control_panel button {
+    height: 60px;
+    min-width: 60px;
+    display: inline-block;
+    margin: 10px 10px;
+    font-size: 48px;
+    border-radius: 8px;
+    border: none;
+    background-color: #dbdbdb;
+    transition-duration: 0.2s;
+}
+#control_panel button:hover {
+    background-color: #c9c9c9;
+}
+
+#device_details {
+    font-family: 'Open Sans', sans-serif;
+    color: white;
+    background-color: #383838;
+    margin-top: 20px;
+    padding: 20px;
+    padding-top: 1px;
+}
+#device_details span {
+    white-space: pre;
+}
+
+#logcat {
+    display: none;
+    font-family: monospace;
+    padding: 10px;
+    color: #aaaaaa;
+    background-color: black;
+    margin-top: 40px;
+}

--- a/templates/instances.html
+++ b/templates/instances.html
@@ -15,7 +15,7 @@
       <tr>
         <td>{{ instance['name'] }}</td>
         <td>
-          <a class="btn btn-link" href="/connect?device_id={{instance.name}}&operator_host={{operator_host}}">connect</a>
+          <a class="btn btn-link" href="/connect?device_id={{instance.name}}">connect</a>
         </td>
         <td>
           <a class="btn btn-link" href="/instance/{{instance.name}}">info</a>

--- a/templates/instances.html
+++ b/templates/instances.html
@@ -28,9 +28,12 @@
   </table>
   {% endif %}
 
+  <input class="mb-4" type="text" placeholder="User id" id="userIdInput">
+  <input class="btn btn-primary" value="+ New Instance" type="button" onclick="createNewInstance()">
+
   <h2>User Disks</h2>
   {% if disks|length < 1 %}
-  <h4>There are no user disks.</h4>
+  <h4>There are no user disks to restore.</h4>
   {% else %}
   <table class="table">
     {% for disk in disks %}
@@ -47,8 +50,6 @@
   </table>
   {% endif %}
 
-  <input class="btn btn-primary" value="+ New Instance" type="button" onclick="createNewInstance()">
-  
 </div>
 
 {% endblock %}

--- a/templates/instances.html
+++ b/templates/instances.html
@@ -15,7 +15,7 @@
       <tr>
         <td>{{ instance['name'] }}</td>
         <td>
-          <a class="btn btn-link" href="/instance/connect/{{instance.name}}">connect</a>
+          <a class="btn btn-link" href="/connect?device_id={{instance.name}}&operator_host={{operator_host}}">connect</a>
         </td>
         <td>
           <a class="btn btn-link" href="/instance/{{instance.name}}">info</a>

--- a/templates/operator.html
+++ b/templates/operator.html
@@ -1,0 +1,54 @@
+<?--
+ Copyright (C) 2019 The Android Open Source Project
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+<html>
+    <head>
+        <title>My Virtual Device Playground</title>
+
+        <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    </head>
+
+    <body>
+      <section id='device_selector'>
+        <h1>Available devices <span id='refresh_list'>&#8635;</span></h1>
+        <ul id="device_list"></ul>
+      </section>
+      <section id='device_connection'>
+        <div id='device_view'>
+          <video id="deviceScreen" autoplay ></video>
+        </div>
+        <div id='control_view'>
+          <button id="keyboardCaptureBtn">Capture Keyboard</button>
+          <button id="showLogcatBtn">Show Logcat</button>
+          <hr>
+          <div id='control_panel'>
+            <h2>Device Controls</h2>
+          </div>
+          <div id='device_details'>
+            <h2>Device Details</h2>
+            <h3>Hardware Configuration</h3>
+            <span id='device_details_hardware'>unknown</span>
+          </div>
+          <textarea id="logcat" rows="55" cols="120" readonly ></textarea>
+        </div>
+      </section>
+
+       <script src="static/logcat.js"></script>
+       <script src="static/cf_webrtc.js" type="module"></script>
+       <script src="static/app.js"></script>
+    </body>
+</html>

--- a/templates/operator.html
+++ b/templates/operator.html
@@ -1,54 +1,41 @@
-<?--
- Copyright (C) 2019 The Android Open Source Project
+{% extends 'base.html' %}
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+{% block head %}
+  <title>Cuttlefish Interface</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+{% endblock %}
 
-      http://www.apache.org/licenses/LICENSE-2.0
+{% block body %}
+<section id='device_selector'>
+  <h1>Available devices <span id='refresh_list'>&#8635;</span></h1>
+  <ul id="device_list"></ul>
+</section>
+<section id='device_connection'>
+  <div id='device_view'>
+    <video id="deviceScreen" autoplay ></video>
+  </div>
+  <div id='control_view'>
+    <button id="keyboardCaptureBtn">Capture Keyboard</button>
+    <button id="showLogcatBtn">Show Logcat</button>
+    <hr>
+    <div id='control_panel'>
+      <h2>Device Controls</h2>
+    </div>
+    <div id='device_details'>
+      <h2>Device Details</h2>
+      <h3>Hardware Configuration</h3>
+      <span id='device_details_hardware'>unknown</span>
+    </div>
+    <textarea id="logcat" rows="55" cols="120" readonly ></textarea>
+  </div>
+</section>
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- -->
-
-<html>
-    <head>
-        <title>My Virtual Device Playground</title>
-
-        <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    </head>
-
-    <body>
-      <section id='device_selector'>
-        <h1>Available devices <span id='refresh_list'>&#8635;</span></h1>
-        <ul id="device_list"></ul>
-      </section>
-      <section id='device_connection'>
-        <div id='device_view'>
-          <video id="deviceScreen" autoplay ></video>
-        </div>
-        <div id='control_view'>
-          <button id="keyboardCaptureBtn">Capture Keyboard</button>
-          <button id="showLogcatBtn">Show Logcat</button>
-          <hr>
-          <div id='control_panel'>
-            <h2>Device Controls</h2>
-          </div>
-          <div id='device_details'>
-            <h2>Device Details</h2>
-            <h3>Hardware Configuration</h3>
-            <span id='device_details_hardware'>unknown</span>
-          </div>
-          <textarea id="logcat" rows="55" cols="120" readonly ></textarea>
-        </div>
-      </section>
-
-       <script src="static/logcat.js"></script>
-       <script src="static/cf_webrtc.js" type="module"></script>
-       <script src="static/app.js"></script>
-    </body>
-</html>
+<script src="static/logcat.js"></script>
+<script src="static/cf_webrtc.js" type="module"></script>
+<script type="text/javascript">
+  var device_id = '{{ data.device_id }}';
+  var operator_host = '{{ data.operator_host }}';
+</script>
+<script type="text/javascript" src="static/app.js"></script>
+{% endblock %}

--- a/templates/operator.html
+++ b/templates/operator.html
@@ -7,10 +7,6 @@
 {% endblock %}
 
 {% block body %}
-<section id='device_selector'>
-  <h1>Available devices <span id='refresh_list'>&#8635;</span></h1>
-  <ul id="device_list"></ul>
-</section>
 <section id='device_connection'>
   <div id='device_view'>
     <video id="deviceScreen" autoplay ></video>

--- a/templates/operator.html
+++ b/templates/operator.html
@@ -31,7 +31,7 @@
 <script src="static/cf_webrtc.js" type="module"></script>
 <script type="text/javascript">
   var device_id = '{{ data.device_id }}';
-  var operator_host = '{{ data.operator_host }}';
+  var sig_server_host = '{{ data.sig_server_host }}';
 </script>
 <script type="text/javascript" src="static/app.js"></script>
 {% endblock %}

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,10 @@
+from server import app
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+if __name__ == "__main__":
+    from gevent import pywsgi
+    from geventwebsocket.handler import WebSocketHandler
+    server = pywsgi.WSGIServer(('', 8000), app, handler_class=WebSocketHandler)
+    server.serve_forever()


### PR DESCRIPTION
Fixes #31 

Implement the webRTC signaling server in python so it manages websocket connections from new CVDs and provide a connection through the browser to them as a client. 

## Features added
- implemented signaling server in python using `Flask-Sockets` library
- configured the endpoint so it sends the relevant data `operator_host` and `device_id` to the cvd connection page when selecting a specific device from the active instances list
- brought and refactored static files that let you visualize the cvd

## Possible improvements
- operator and main flask server could be merged into a single application

## Bugs
- when websockets from the device are disconnected they should be managed in the device list.